### PR TITLE
(doc) build-yocto-fsl-arm: Cleanup comments

### DIFF
--- a/build-yocto-fsl-arm/Dockerfile
+++ b/build-yocto-fsl-arm/Dockerfile
@@ -1,5 +1,6 @@
 # ===========================================================================================
-# Dockerfile for building a Yocto-based distro for Wandboard
+# Dockerfile for building a Yocto-based distro for Freescale/ARM
+# (example: i.MX6Q SABRE, Wandboard, etc.)
 # 
 # References:
 #	http://elinux.org/Getting_started_with_Yocto_on_Wandboard


### PR DESCRIPTION
Make it clear that Wandboard is just one of the supported targets

Signed-off-by: Gianpaolo Macario gianpaolo_macario@mentor.com
