### PR TITLE
Make sure /home/build/shared dir exists in the container

### DIFF
--- a/build-yocto-genivi/Dockerfile
+++ b/build-yocto-genivi/Dockerfile
@@ -44,6 +44,7 @@ RUN su -c "cd ~/genivi-baseline \
 RUN su -c "cd ~/genivi-baseline \
 	&& git clone git://git.openembedded.org/meta-openembedded" build
 
+RUN mkdir -p /home/build/shared
 COPY configure_build.sh /home/build/
 RUN chown -R build.build /home/build
 


### PR DESCRIPTION
Fixes https://github.com/gmacario/easy-build/issues/66

Signed-off-by: Gianpaolo Macario gianpaolo_macario@mentor.com
