### PR TITLE
build-openwrt/run.sh: Use container name from commandline if provided

### DIFF
--- a/build-openwrt/run.sh
+++ b/build-openwrt/run.sh
@@ -4,9 +4,13 @@
 
 cd $(dirname $0)
 
-SHAREDDIR=$PWD/shared
-CONTAINER=build-openwrt
+if [ "$1" != "" ]; then
+    CONTAINER=$1
+else
+    CONTAINER=build-openwrt
+fi
 REPOSITORY=gmacario/build-openwrt
+SHAREDDIR=$PWD/shared
 
 # Create a shared folder which will be used as working directory.
 mkdir -p $SHAREDDIR

--- a/build-openwrt/run.sh
+++ b/build-openwrt/run.sh
@@ -18,10 +18,10 @@ mkdir -p $SHAREDDIR
 # Try to start an existing/stopped container with the given name $CONTAINER.
 # Otherwise, run a new one.
 if docker inspect $CONTAINER >/dev/null 2>&1; then
-    echo -e "\nINFO: Reattaching to running container\n"
+    echo -e "\nINFO: Reattaching to running container \"$CONTAINER\"\n"
     docker start -i $CONTAINER
 else
-    echo -e "\nINFO: Creating a new container\n"
+    echo -e "\nINFO: Creating a new container \"$CONTAINER\" from image \"$REPOSITORY\"\n"
     docker run -v $SHAREDDIR:/shared -i -t \
 	--name $CONTAINER $REPOSITORY
 fi


### PR DESCRIPTION
First cut at fixing https://github.com/gmacario/easy-build/issues/103

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>