### PR TITLE
build-aosp: Install prerequisite packages

### DIFF
--- a/build-aosp/Dockerfile
+++ b/build-aosp/Dockerfile
@@ -8,33 +8,45 @@
 FROM gmacario/easy-build
 #FROM ubuntu
 
-MAINTAINER Gianpaolo Macario, gmacario@gmail.com
+MAINTAINER Gianpaolo Macario <gmacario@gmail.com>
+
+# See https://github.com/docker/docker/issues/4032
+ENV DEBIAN_FRONTEND noninteractive
 
 # Make sure the package repository is up to date
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
-RUN apt-get update
+RUN sed -i 's/main$/main universe/' /etc/apt/sources.list
+RUN dpkg --add-architecture i386
+RUN apt-get -qq update
 
 # Install essential packages
-RUN apt-get install -y git tig
+RUN apt-get install -y curl
+RUN apt-get install -y git
+RUN apt-get install -y tig
 RUN apt-get install -y mc
+RUN apt-get install -y rsync
 RUN apt-get install -y screen
 
-# Install required packages
-# See https://source.android.com/source/building.html
-RUN apt-get install -y curl
-RUN apt-get install -y python
-RUN apt-get install -y make
-#RUN apt-get install -y openjdk-7-jdk
-
-# Create non-root user that will perform the build of the images
-#RUN useradd --shell /bin/bash build
-#RUN mkdir -p /home/build
-#RUN chown -R build /home/build
-
 # See https://source.android.com/source/initializing.html
-
+#
+# The master branch of Android in the Android Open Source Project (AOSP)
+# requires Java 7. On Ubuntu, use OpenJDK.
+# To develop older versions of Android, download and install
+# the corresponding version of the Java JDK (not OpenJDK):
+# * Java 6: for Gingerbread through KitKat
+# * Java 5: for Cupcake through Froyo
+#
+#RUN apt-get install -y openjdk-7-jdk
+#
 #RUN update-alternatives --config java
 #RUN update-alternatives --config javac
+#
+# Installing required packages (Ubuntu 14.04)
+#
+RUN apt-get install -y bison build-essential ccache flex
+RUN apt-get install -y g++-multilib gcc-multilib git gperf
+RUN apt-get install -y lib32stdc++6 lib32z1 lib32z1-dev
+RUN apt-get install -y libxml2-utils make python zip
+RUN apt-get install -y zlib1g-dev:i386
 
 #RUN apt-get install -y git gnupg flex bison gperf build-essential \
 #  zip curl libc6-dev libncurses5-dev:i386 x11proto-core-dev \
@@ -43,6 +55,13 @@ RUN apt-get install -y make
 #  python-markdown libxml2-utils xsltproc zlib1g-dev:i386
 #RUN ln -s /usr/lib/i386-linux-gnu/mesa/libGL.so.1 \
 #	/usr/lib/i386-linux-gnu/libGL.so
+
+RUN apt-get -qqy dist-upgrade
+
+# Create non-root user that will perform the build of the images
+#RUN useradd --shell /bin/bash build
+#RUN mkdir -p /home/build
+#RUN chown -R build /home/build
 
 # Downloading the Source
 # See https://source.android.com/source/downloading.html


### PR DESCRIPTION
Update Dockerfile to install extra Ubuntu packages as detailed in
https://source.android.com/source/initializing.html

Fix https://github.com/gmacario/easy-build/issues/169

Signed-off-by: Gianpaolo Macario <gianpaolo_macario@mentor.com>