### PR TITLE
Added support for gunnarx/genivi-demo-platform

### DIFF
--- a/build-gdp/Dockerfile
+++ b/build-gdp/Dockerfile
@@ -1,0 +1,33 @@
+# ===========================================================================================
+# Base Dockerfile for building embedded distros
+# 
+# References:
+#	https://www.docker.io/learn/dockerfile/level1/
+#	https://www.docker.io/learn/dockerfile/level2/
+# ===========================================================================================
+
+FROM ubuntu:12.04
+MAINTAINER Arthur Taylor, arthur@advancedtelematic.com
+
+# Make sure the package repository is up to date
+RUN apt-get update
+
+# Install required packages
+RUN apt-get install -y git tig mc
+RUN apt-get install -y make gcc g++ diffstat texinfo gawk chrpath wget python libsdl1.2-dev curl bzip2
+
+# Create non-root user that will perform the build of the images
+RUN useradd --shell /bin/bash build
+RUN mkdir -p /home/build
+RUN chown -R build /home/build
+
+# Download and build GDP Code from Gunnar's repo
+RUN su -c "cd ~ && git clone --recursive https://github.com/gunnarx/genivi-demo-platform.git -b qemux86-64" build
+RUN su -c "cd ~/genivi-demo-platform && source init.sh && bitbake genivi-demo-platform" build
+
+RUN cd /home/build
+
+# Run as the following user
+USER build
+
+ENTRYPOINT ["/bin/bash"]

--- a/build-gdp/README.md
+++ b/build-gdp/README.md
@@ -1,0 +1,18 @@
+## Setup
+
+To build this docker image, you will need your Docker server configured to support base filesystem images larger than 10GB. The documentation suggests that starting docker with:
+
+    docker -d -s=devicemapper --storage-opt dm.basesize=30G
+
+should suffice.
+
+## Building locally
+
+    docker build -t genivi-demo-platform .
+
+### Running docker manually
+
+This command will create and start a new container
+
+    docker run -it genivi-demo-platform
+


### PR DESCRIPTION
I tried to get Gunnar's genivi-demo-platform repo to build with easy-build. Actually I didn't succeed because I can't make my docker base images larger than 10GB (for some reason), but I have to focus on something else now so I thought I would share this (untested) Dockerfile in case it's of use to anyone. It gets 50% through the build on my machine.