### PR TITLE
build-yocto-fsl-arm/Dockerfile: Set USER root before apt-get

### DIFF
--- a/build-yocto-fsl-arm/Dockerfile
+++ b/build-yocto-fsl-arm/Dockerfile
@@ -7,8 +7,9 @@
 # ===========================================================================================
 
 FROM gmacario/build-yocto
-
 MAINTAINER Gianpaolo Macario <gmacario@gmail.com>
+
+USER root
 
 # Install the following utilities (required later)
 RUN apt-get -y install curl


### PR DESCRIPTION
Fix https://github.com/gmacario/easy-build/issues/220

Signed-off-by: Gianpaolo Macario <gianpaolo_macario@mentor.com>