### PR TITLE
build-yocto-genivi/Dockerfile: Install librsvg2-bin

### DIFF
--- a/build-yocto-genivi/Dockerfile
+++ b/build-yocto-genivi/Dockerfile
@@ -56,6 +56,9 @@ RUN apt-get -y install curl make gcc g++ diffstat texinfo gawk chrpath wget libs
 # Install extra packages (required for building GDP)
 RUN apt-get -y install gawk wget git-core diffstat unzip texinfo gcc-multilib \
     build-essential chrpath socat libsdl1.2-dev xterm git-svn
+    
+# See https://at.projects.genivi.org/jira/browse/GDP-92
+RUN apt-get -y install librsvg2-bin
 
 # Make sure the directory exists, otherwise sshd will not start
 RUN mkdir -p /var/run/sshd


### PR DESCRIPTION
Workaround for bug https://at.projects.genivi.org/jira/browse/GDP-92

Notice that this is a workaround to an actual bug inside some GDP recipes,
since host binary `rsvg-convert` is built and installed in `tmp/sysroots/x86_64-linux/usr/bin/`,
but apparently it does not properly handle `*.svgz` files.

See also http://comments.gmane.org/gmane.linux.debian.devel.bugs.general/1185230

Signed-off-by: Gianpaolo Macario <gianpaolo_macario@mentor.com>