### PR TITLE
build-yocto: Install npm

### DIFF
--- a/build-yocto/Dockerfile
+++ b/build-yocto/Dockerfile
@@ -41,7 +41,8 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
 # See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues
 RUN apt -y install locales && \
   dpkg-reconfigure locales && \
-  update-locale LC_ALL=en_us.UTF-8 LANG=en_US.UTF-8
+  locale-gen en_US.UTF-8 && \
+  update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
 # Add "repo" tool (used by many Yocto-based projects)
 RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo

--- a/build-yocto/Dockerfile
+++ b/build-yocto/Dockerfile
@@ -37,6 +37,12 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
+# Fix error "Please use a locale setting which supports utf-8."
+# See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues
+RUN apt -y install locales && \
+  dpkg-reconfigure locales && \
+  update-locale LC_ALL=en_us.UTF-8 LANG=en_US.UTF-8
+
 # Add "repo" tool (used by many Yocto-based projects)
 RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo
 RUN chmod a+x /usr/local/bin/repo

--- a/build-yocto/Dockerfile
+++ b/build-yocto/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk g
 # Additional host packages required by poky/scripts/wic
 RUN apt-get install -y bzip2 dosfstools mtools parted syslinux tree
 
-# Install nodejs and npm"(used for building Resin OS)
+# Install nodejs and npm (required for building Resin OS)
+#
 # gpg keys listed at https://github.com/nodejs/node#release-team
 RUN set -ex \
   && for key in \

--- a/build-yocto/Dockerfile
+++ b/build-yocto/Dockerfile
@@ -8,8 +8,32 @@ RUN apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk g
 # Additional host packages required by poky/scripts/wic
 RUN apt-get install -y bzip2 dosfstools mtools parted syslinux tree
 
-# Add "npm" tool (used for building Resin OS)
-RUN apt -y install npm
+# Install nodejs and npm"(used for building Resin OS)
+# gpg keys listed at https://github.com/nodejs/node#release-team
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+#
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 6.10.1
+#
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
 # Add "repo" tool (used by many Yocto-based projects)
 RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo

--- a/build-yocto/Dockerfile
+++ b/build-yocto/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk g
 # Additional host packages required by poky/scripts/wic
 RUN apt-get install -y bzip2 dosfstools mtools parted syslinux tree
 
+# Add "npm" tool (used for building Resin OS)
+RUN apt -y install npm
+
 # Add "repo" tool (used by many Yocto-based projects)
 RUN curl http://storage.googleapis.com/git-repo-downloads/repo > /usr/local/bin/repo
 RUN chmod a+x /usr/local/bin/repo

--- a/build-yocto/Dockerfile
+++ b/build-yocto/Dockerfile
@@ -8,7 +8,8 @@ RUN apt-get install -y build-essential chrpath curl diffstat gcc-multilib gawk g
 # Additional host packages required by poky/scripts/wic
 RUN apt-get install -y bzip2 dosfstools mtools parted syslinux tree
 
-# Install nodejs and npm (required for building Resin OS)
+# Install jq, nodejs and npm (required for building Resin OS)
+RUN apt -y install jq
 #
 # gpg keys listed at https://github.com/nodejs/node#release-team
 RUN set -ex \


### PR DESCRIPTION
Prerequisite for building several Yocto-based distros (most notably Resin OS)

See <https://resinos.io/docs/custombuild/>

Signed-off-by: Gianpaolo Macario <gianpaolo_macario@mentor.com>