### PR TITLE
experimental: Add build-resinos

### DIFF
--- a/experimental/build-resinos/Dockerfile
+++ b/experimental/build-resinos/Dockerfile
@@ -1,0 +1,51 @@
+# Docker image for building Resin OS
+
+FROM gmacario/build-yocto:latest
+
+USER root
+
+# Install jq
+RUN apt -y install jq
+
+# Install nodejs and npm
+# NOTE: Do not use the ones shipping with base OS (Ubuntu 14.04) as they are too old
+#
+# gpg keys listed at https://github.com/nodejs/node#release-team
+RUN set -ex \
+  && for key in \
+    9554F04D7259F04124DE6B476D5A82AC7E37093B \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+  ; do \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+  done
+#
+ENV NPM_CONFIG_LOGLEVEL info
+ENV NODE_VERSION 6.10.1
+#
+RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
+  && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+  && grep " node-v$NODE_VERSION-linux-x64.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+  && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 \
+  && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+# Fix error "Please use a locale setting which supports utf-8."
+# TODO: Should move to base Docker image (gmacario/build-yocto)
+#
+# See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues
+RUN apt -y install locales && \
+  dpkg-reconfigure locales && \
+  locale-gen en_US.UTF-8 && \
+  update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+ 
+ # Switch back to default user
+ USER build
+ 
+ # EOF

--- a/experimental/build-resinos/Dockerfile
+++ b/experimental/build-resinos/Dockerfile
@@ -36,15 +36,6 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
   && ln -s /usr/local/bin/node /usr/local/bin/nodejs
 
-# Fix error "Please use a locale setting which supports utf-8."
-# TODO: Should move to base Docker image (gmacario/build-yocto)
-#
-# See https://wiki.yoctoproject.org/wiki/TipsAndTricks/ResolvingLocaleIssues
-RUN apt -y install locales && \
-  dpkg-reconfigure locales && \
-  locale-gen en_US.UTF-8 && \
-  update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
- 
  # Switch back to default user
  USER build
  


### PR DESCRIPTION
Add definition for a new experimental Docker image
which extends gmacario/build-yocto:latest
and may be used for building [Resin OS](https://resinos.io/)

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>