### PR TITLE
Fix error: Please use a locale setting which supports utf-8

### DIFF
--- a/build-yocto/Dockerfile
+++ b/build-yocto/Dockerfile
@@ -26,6 +26,12 @@ RUN apt -y install locales && \
   locale-gen en_US.UTF-8 && \
   update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
+RUN echo " \n\
+export LC_ALL=en_US.UTF-8 \n\
+export LANG=en_US.UTF-8 \n\
+export LANGUAGE=en_US.UTF-8 \n\
+" >> /home/build/.profile
+
 USER build
 WORKDIR /home/build
 CMD "/bin/bash"

--- a/build-yocto/Dockerfile
+++ b/build-yocto/Dockerfile
@@ -26,11 +26,9 @@ RUN apt -y install locales && \
   locale-gen en_US.UTF-8 && \
   update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 
-RUN echo " \n\
-export LC_ALL=en_US.UTF-8 \n\
-export LANG=en_US.UTF-8 \n\
-export LANGUAGE=en_US.UTF-8 \n\
-" >> /home/build/.bashrc
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
 
 USER build
 WORKDIR /home/build

--- a/build-yocto/Dockerfile
+++ b/build-yocto/Dockerfile
@@ -30,7 +30,7 @@ RUN echo " \n\
 export LC_ALL=en_US.UTF-8 \n\
 export LANG=en_US.UTF-8 \n\
 export LANGUAGE=en_US.UTF-8 \n\
-" >> /home/build/.profile
+" >> /home/build/.bashrc
 
 USER build
 WORKDIR /home/build


### PR DESCRIPTION
This should fix https://github.com/gmacario/easy-build/issues/256

The yocto master print's out that error while using `bitbake`:

```
Please use a locale setting which supports utf-8.
Python can't change the filesystem locale after loading so we need a
utf-8 when python starts or things won't work.
```