### PR TITLE
build-aosp: Dockerfile: add missing schedtools

### DIFF
--- a/build-aosp/Dockerfile
+++ b/build-aosp/Dockerfile
@@ -46,7 +46,7 @@ RUN update-alternatives --config javac
 RUN apt-get -y install git-core gnupg flex bison gperf build-essential \
   zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 \
   lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache \
-  libgl1-mesa-dev libxml2-utils xsltproc unzip
+  libgl1-mesa-dev libxml2-utils schedtool xsltproc unzip
 #
 # Note: To use SELinux tools for policy analysis, also install the python-networkx package.
 RUN apt-get -y install python-networkx


### PR DESCRIPTION
schedtool is required (tested with AOSP 5.1.1):

```
============================================
PLATFORM_VERSION_CODENAME=REL
PLATFORM_VERSION=5.1.1
CM_VERSION=12.1-20180422-UNOFFICIAL-ms345
TARGET_PRODUCT=cm_ms345
TARGET_BUILD_VARIANT=userdebug
TARGET_BUILD_TYPE=release
TARGET_BUILD_APPS=
TARGET_ARCH=arm
TARGET_ARCH_VARIANT=armv7-a-neon
TARGET_CPU_VARIANT=cortex-a53
TARGET_2ND_ARCH=
TARGET_2ND_ARCH_VARIANT=
TARGET_2ND_CPU_VARIANT=
HOST_ARCH=x86_64
HOST_OS=linux
HOST_OS_EXTRA=Linux-4.14.14-gentoo-x86_64-with-Ubuntu-14.04-trusty
HOST_BUILD_TYPE=release
BUILD_ID=LMY49J
OUT_DIR=/home/build/aosp/out
============================================

bash: schedtool: command not found

```