### PR TITLE
(#286) Fixing typo in DEBIAN_FRONTEND environment variable

### DIFF
--- a/build-yocto/Dockerfile
+++ b/build-yocto/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-ENV DEBIAN_FRONTENV noninteractive
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get -y upgrade
 


### PR DESCRIPTION
Changing the environment variable DEBIAN_FRONTENV to DEBIAN_FRONTEND
to make non-interactive installation of packages work in the Yocto
build image.