### PR TITLE
(#293) Fixing Google repo execution in the Yocto Docker image

### DIFF
--- a/build-yocto/Dockerfile
+++ b/build-yocto/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTENV noninteractive
 
@@ -6,9 +6,10 @@ RUN apt-get update && apt-get -y upgrade
 
 # Required Packages for the Host Development System
 # http://www.yoctoproject.org/docs/latest/mega-manual/mega-manual.html#required-packages-for-the-host-development-system
-RUN apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib g++-multilib \
-     build-essential chrpath socat cpio python python3 python3-pip python3-pexpect \
-     apt-utils tmux xz-utils debianutils iputils-ping libncurses5-dev
+RUN apt-get install -y gawk wget git-core diffstat unzip texinfo gcc-multilib \
+        build-essential chrpath socat cpio python3 python3-pip python3-pexpect python-is-python3 \
+        xz-utils debianutils iputils-ping python3-git python3-jinja2 libegl1-mesa libsdl1.2-dev \
+        pylint3 xterm
 
 # Additional host packages required by poky/scripts/wic
 RUN apt-get install -y curl dosfstools mtools parted syslinux tree zip


### PR DESCRIPTION
Updating the Yocto build container to Ubuntu 20.04 and making Python 3.8
the default Python version.